### PR TITLE
Fixed Removing lodlights

### DIFF
--- a/gtautil/Program/GenLODLights.cs
+++ b/gtautil/Program/GenLODLights.cs
@@ -140,8 +140,9 @@ namespace GTAUtil
 
                     foreach (var item in modified)
                     {
-                        item.Value.Save(opts.InputDirectory + "\\" + item.Key + ".ymap");
-                        item.Value.Save(opts.InputDirectory + "\\modified\\" + item.Key + ".ymap");
+                        var descendant = item.Key.Substring(item.Key.LastIndexOf("\\"));
+                        item.Value.Save(opts.InputDirectory + "\\" + descendant + ".ymap");
+                        item.Value.Save(opts.InputDirectory + "\\modified\\" + descendant + ".ymap");
                     }
                 }
 


### PR DESCRIPTION
Me and some friends had some issues with removing lodlights, the application basically tried to find the file but **doubled** to input path ex: _lodlights/lodlight__small_32.ymap_ **INTO** _lodlights/lodlights/lodlight__small_32.ymap_ 

![image](https://user-images.githubusercontent.com/39080460/104489406-e300be00-55cf-11eb-841f-d24098463789.png)
